### PR TITLE
add shadow to card hover effect

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -30,11 +30,12 @@ body {font-family: "Ubuntu", sans-serif}
   background: #777;
 }
 
-.grow {
+.lift {
   transition: all 0.2s ease-in-out;
 }
-.grow:hover {
+.lift:hover {
   transform: scale(1.025);
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/react/app/Home/components/RecipeCard.tsx
+++ b/src/react/app/Home/components/RecipeCard.tsx
@@ -15,7 +15,7 @@ function RecipeCard({ recipe }: IRecipeCardProps) {
   return (
     <div className="column is-half-tablet is-one-third-desktop">
       <Link to={`/recipe/${recipe.id}`}>
-        <div className="card grow">
+        <div className="card lift">
           <div
             className="card-content is-flex is-flex-direction-column"
             style={{ height: '14em' }}

--- a/src/react/app/MyAccount/components/SmallRecipeCard.tsx
+++ b/src/react/app/MyAccount/components/SmallRecipeCard.tsx
@@ -10,7 +10,7 @@ function SmallRecipeCard({ recipe }: ISmallRecipeCardProps) {
   return (
     <div className="column is-full-tablet">
       <Link to={`/recipe/${recipe.id}`}>
-        <div className="card grow">
+        <div className="card lift">
           <div
             className="card-content is-flex is-flex-direction-column"
             style={{ height: '8em' }}

--- a/src/react/components/FavoriteButton.tsx
+++ b/src/react/components/FavoriteButton.tsx
@@ -29,9 +29,7 @@ function FavoriteButton({ recipeId, favoriteIds, fetchFavorites }: IProps) {
 
   return (
     <div>
-      <IconContext.Provider
-        value={{ size: '1.3em', color: '#E00', className: 'grow' }}
-      >
+      <IconContext.Provider value={{ size: '1.3em', color: '#E00' }}>
         {recipeId && favoriteIds.includes(recipeId) ? (
           <BsHeartFill onClick={removeFavorite} />
         ) : (


### PR DESCRIPTION
also renamed the class from `grow` to `lift` to match the high-level intent: the visual effect is we're lifting the card. It just happens to be done by making the card a bit larger and adding shadow.